### PR TITLE
Provide 'steps' value to template definition

### DIFF
--- a/routes/routes-application.js
+++ b/routes/routes-application.js
@@ -624,6 +624,7 @@ router.post('/show/:foldername/config', spxAuth.CheckLogin, async (req, res) => 
         if (!SPXGCTemplateDefinition.out)         {SPXGCTemplateDefinition.out         = "manual"};
         if (!SPXGCTemplateDefinition.dataformat)  {SPXGCTemplateDefinition.dataformat  = "xml"};
         if (!SPXGCTemplateDefinition.uicolor)     {SPXGCTemplateDefinition.uicolor     = "0"};
+        if (!SPXGCTemplateDefinition.steps)       {SPXGCTemplateDefinition.steps       = "1"};
 
         // v.1.0.15 add imported timestamp
         SPXGCTemplateDefinition.imported = String(Date.now()); // epoch. This COULD be used to compare template versions in profile/rundown.


### PR DESCRIPTION
Without having the 'steps' value available in the template, there's nothing to copy when building the rundown, hence the 'continue' button does not function properly.